### PR TITLE
Moves extra deploy steps to before_deploy lifecycle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,13 +25,13 @@ jobs:
       name: "Build and publish to NPM"
       node_js: 'node'
       script: skip
+      before_deploy:
+        - echo "Building..."
+        - yarn build:ci
+        - echo "Deploying..."
       deploy:
         provider: script
-        skip_cleanup: true # will be deprecated in dpl2
         script:
-          - echo "Building.."
-          - yarn build:ci
-          - echo "Publishing to NPM..."
           - yarn semantic-release
         on:
           branch: master


### PR DESCRIPTION
Travis only allows a single line of commands for the deploy script for some reason