### PR TITLE
chore: remove test:build command. Runs tests against src as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,6 @@ jobs:
       before_deploy:
         - echo "Building..."
         - yarn build:ci
-        - echo "Testing build..."
-        - yarn test:build
         - echo "Deploying..."
       deploy:
         provider: script


### PR DESCRIPTION
Not entirely sure why it also runs tests against src.
If I execute the script locally it runs exactly one test suite, against build. On Travis it runs 2 suites, one against build and one against src. We do run a full test in a previous stage, so I think we're safe removing this one.