### PR TITLE
Bugfix/allow objects for value

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,15 +42,30 @@ resources:
 custom:
   secretToken: ${opt:secretToken}
 
+  someConfiguration:
+    foo: bar
+    baz: 1
+    more:
+      - stuff
+      - here
+
   ssmPublish:
-    enabled: true                             # Needs to be set to true
+    enabled: true                                # Needs to be set to true
     params:
+      # simple usage, `value` is a string
       - path: /global/tokens/secretToken
         value: ${self:custom.secretToken}
-        description: Super Secret Token       # description is optional
-        secure: true                          # defaults to true
+        description: Super Secret Token          # description is optional
+        secure: true                             # defaults to true
+
+      # `value` can be an object; it is serialized to YAML before upload to SSM
+      - path: /global/tokens/secretToken
+        value: ${self:custom.someConfiguration}
+
+      # `source` can be used as an alternative to `value`. If `source` is given, ssmPublish will retrieve
+      # the matching value from the service's CloudFormation Stack Outputs
       - path: /service/config/storageBucket
-        source: ExampleStaticValue            # source can be used as an alternative to value. If source is given, ssmPublish will retrieve the matching value from the service's Cloud Formation Output
+        source: ExampleStaticValue
         secure: false
 ```
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,3 @@ You can also call the plugin directly in order to update SSM params without runn
 `sls ssmPublish`
 
 ## [Changelog](./CHANGELOG.md)
-
-## Version History
-*0.1.0
-  - Initial release

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   },
   "dependencies": {
     "chalk": "^3.0.0",
+    "js-yaml": "^3.13.1",
     "prompt": "^1.0.0",
     "serverless": "^1.67.0"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
-import { CloudFormation , SSM } from 'aws-sdk';
+import { CloudFormation, SSM } from 'aws-sdk';
 import chalk from 'chalk';
 import * as util from 'util';
 
-import { ServerlessInstance, SSMParam, SSMParamCloudFormation, SSMParamWithValue   } from './types';
+import { ServerlessInstance, SSMParam, SSMParamCloudFormation, SSMParamWithValue } from './types';
 import { compareParams, evaluateEnabled, validateParams } from './util';
 
 const unsupportedRegionPrefixes = [
@@ -35,10 +35,27 @@ class ServerlessSSMPublish {
   private existingUnchangedParams: SSMParamWithValue[];
   private cloudFormationOutput: SSMParamWithValue[] | undefined;
 
+  private static prettifyCFOutput(stackResult: CloudFormation.DescribeStacksOutput): SSMParamWithValue[] {
+    if (!stackResult.Stacks) return [];
+
+    const stackOutput = stackResult.Stacks[0].Outputs;
+
+    if (!stackOutput) return [];
+
+    const formattedParams = stackOutput
+      // ensure output matches our formatting
+      .map((output) => ({
+      path: output.OutputKey || '',
+      value: output.OutputValue || '',
+      description: output.Description,
+    }));
+
+    return formattedParams || [];
+  }
+
   /**
    * Constructor
    * @param serverless
-   * @param options
    */
   constructor(serverless: ServerlessInstance) {
     this.serverless = serverless;
@@ -209,10 +226,7 @@ class ServerlessSSMPublish {
 }
   private async retrieveAndFormatCloudFormationOutput(): Promise<SSMParamWithValue[]> {
     const stackResult = await this.fetchCFOutput();
-
-    const outputForSSM = this.prettifyCFOutput(stackResult);
-
-    return outputForSSM;
+    return ServerlessSSMPublish.prettifyCFOutput(stackResult);
   }
 
   private async fetchCFOutput(): Promise<CloudFormation.DescribeStacksOutput> {
@@ -223,24 +237,6 @@ class ServerlessSSMPublish {
       this.serverless.getProvider('aws').getStage(),
       this.serverless.getProvider('aws').getRegion(),
     );
-  }
-
-  private prettifyCFOutput(stackResult: CloudFormation.DescribeStacksOutput): SSMParamWithValue[] {
-    if (!stackResult.Stacks) return [];
-
-    const stackOutput = stackResult.Stacks[0].Outputs;
-
-    if (!stackOutput) return [];
-
-    const formattedParams = stackOutput
-      // ensure output matches our formatting
-      .map((output) => ({
-      path: output.OutputKey || '',
-      value: output.OutputValue || '',
-      description: output.Description,
-    }));
-
-    return formattedParams || [];
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -216,7 +216,7 @@ class ServerlessSSMPublish {
       {
         Name: param.path,
         Description: param.description || `Placed by ${this.serverless.service.getServiceName()} - serverless-ssm-plugin`,
-        Value: param.value,
+        Value: typeof param.value === 'string' ? param.value : JSON.stringify(param.value),
         Overwrite: true,
         Type: param.secure ? 'SecureString' : 'String',
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { CloudFormation, SSM } from 'aws-sdk';
 import chalk from 'chalk';
+import yaml from 'js-yaml';
 import * as util from 'util';
 
 import { ServerlessInstance, SSMParam, SSMParamCloudFormation, SSMParamWithValue } from './types';
@@ -216,7 +217,7 @@ class ServerlessSSMPublish {
       {
         Name: param.path,
         Description: param.description || `Placed by ${this.serverless.service.getServiceName()} - serverless-ssm-plugin`,
-        Value: typeof param.value === 'string' ? param.value : JSON.stringify(param.value),
+        Value: typeof param.value === 'string' ? param.value : yaml.safeDump(param.value),
         Overwrite: true,
         Type: param.secure ? 'SecureString' : 'String',
       },

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,9 +2,9 @@ declare class AwsProvider {
 
   constructor(serverless: ServerlessInstance, options: Options)
 
-  public getProviderName(): string;
+  // public getProviderName(): string;
   public getRegion(): string;
-  public getServerlessDeploymentBucketName(): string;
+  // public getServerlessDeploymentBucketName(): string;
   public getStage(): string;
   public request(service: string, method: string, data: { }, stage: string, region: string): Promise<any>; // tslint:disable-line:no-any
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,7 +58,7 @@ export interface SSMParamCloudFormation extends BaseSSMParam {
 }
 
 export interface SSMParamWithValue extends BaseSSMParam {
-  value: string;
+  value: string | object;
 }
 
 export type SSMParam = SSMParamWithValue | SSMParamCloudFormation;

--- a/src/util.ts
+++ b/src/util.ts
@@ -87,7 +87,7 @@ export const compareParams = (localParams: SSMParamWithValue[], remoteParams: SS
     acc.nonExistingParams.push(curr);
     return acc;
   }
-  if (existingParam.Value === curr.value) {
+  if (existingParam.Value === (typeof curr.value === 'string' ? curr.value : JSON.stringify(curr.value))) {
     acc.existingUnchangedParams.push(curr);
     return acc;
   }

--- a/src/util.ts
+++ b/src/util.ts
@@ -71,7 +71,7 @@ export const validateParams = (params: ServerlessInstance['service']['custom']['
       if (param.description && param.description.length > maxDescriptionLength)
         throwFunction(`Param ${param.path} description is too long`);
 
-      return { ...param, secure: param.secure === false ? false : true };
+      return { ...param, secure: param.secure !== false };
     };
 
     return params.map(validateParam);

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,6 @@
 import { SSM } from 'aws-sdk';
 import chalk from 'chalk';
+import yaml from 'js-yaml';
 
 import { ServerlessInstance, SSMParam, SSMParamWithValue } from './types';
 
@@ -87,7 +88,7 @@ export const compareParams = (localParams: SSMParamWithValue[], remoteParams: SS
     acc.nonExistingParams.push(curr);
     return acc;
   }
-  if (existingParam.Value === (typeof curr.value === 'string' ? curr.value : JSON.stringify(curr.value))) {
+  if (existingParam.Value === (typeof curr.value === 'string' ? curr.value : yaml.safeDump(curr.value))) {
     acc.existingUnchangedParams.push(curr);
     return acc;
   }


### PR DESCRIPTION
Allow syntax such as:

```yaml
- path: /my/value
  value:
    some: text
    right: here
```

`value` is YAML stringified so we end up with this in SSM:

```text
some: text
right: here
```