### PR TITLE
chore: applicable node engines:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ jobs:
         - yarn codecov
     - stage: publish
       name: "Build and publish to NPM"
-      node_js: "14"
       script: skip
       before_deploy:
         - echo "Building..."

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ jobs:
   include:
     - stage: install
       name: "Install Dependencies"
-      script: yarn
+      script: yarn install --frozen-lockfile
     - stage: test
       name: "Unit Tests + Coverage"
       script:
@@ -22,7 +22,7 @@ jobs:
         - yarn codecov
     - stage: publish
       name: "Build and publish to NPM"
-      node_js: 'node'
+      node_js: "14"
       script: skip
       before_deploy:
         - echo "Building..."

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: node_js
 
 node_js:
-  - "node"
-  - 14
+  - "14"
 
 cache: yarn
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 
 node_js:
   - "node"
-  - "lts/*"
+  - 14
 
 cache: yarn
 

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   },
   "homepage": "https://github.com/mysense-ai/ServerlessPlugin-SSMPublish#readme",
   "engines": {
-    "node": ">=10.0.0 <14.19.3",
-    "npm": ">=6.13.1 <6.14.7"
+    "node": ">=10.0.0 <=14.19.3",
+    "npm": ">=6.13.1 <=6.14.7"
   },
   "private": false,
   "repository": {

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   },
   "homepage": "https://github.com/mysense-ai/ServerlessPlugin-SSMPublish#readme",
   "engines": {
-    "node": ">=10.0.0",
-    "npm": ">=6.13.1"
+    "node": ">=10.0.0 <14.19.3",
+    "npm": ">=6.13.1 <6.14.7"
   },
   "private": false,
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
-  {
+{
   "name": "serverless-ssm-publish",
   "version": "1.4.1",
   "description": "Serverless Framework plugin to publish data to AWS SSM Parameter Store",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
-{
+  {
   "name": "serverless-ssm-publish",
   "version": "1.4.1",
   "description": "Serverless Framework plugin to publish data to AWS SSM Parameter Store",
@@ -10,7 +10,7 @@
   "homepage": "https://github.com/mysense-ai/ServerlessPlugin-SSMPublish#readme",
   "engines": {
     "node": ">=10.0.0",
-    "npm": "6.13.1"
+    "npm": ">=6.13.1"
   },
   "private": false,
   "repository": {


### PR DESCRIPTION
https://www.serverless.com/framework/docs/guides/upgrading-v3 - depicts that the node version for serverless > 2 requires a node version > 10. 
It doesn't specify whether there's a cap on the node version or npm version so I think we should be good 