### PR TITLE
chore:  fix issue with unsupported engine 

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   },
   "homepage": "https://github.com/mysense-ai/ServerlessPlugin-SSMPublish#readme",
   "engines": {
-    "node": ">=10.0.0 <=14.19.3",
-    "npm": ">=6.13.1 <=6.14.7"
+    "node": ">=14.0.0 <=16.18.1",
+    "npm": ">=6.14.8 <=8.19.2"
   },
   "private": false,
   "repository": {


### PR DESCRIPTION
Upgrade engine in package.json to remove warning during install
```
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'serverless-ssm-publish@1.4.1',
npm WARN EBADENGINE   required: { node: '>=10.0.0', npm: '6.13.1' },
npm WARN EBADENGINE   current: { node: 'v16.13.0', npm: '8.1.4' }
npm WARN EBADENGINE }
```