### PR TITLE
Remove upper engine version restrictions in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   },
   "homepage": "https://github.com/mysense-ai/ServerlessPlugin-SSMPublish#readme",
   "engines": {
-    "node": ">=14.0.0 <=16.18.1",
-    "npm": ">=6.14.8 <=8.19.2"
+    "node": ">=14.0.0",
+    "npm": ">=6.14.8"
   },
   "private": false,
   "repository": {


### PR DESCRIPTION
This fixes #143 by still retaining the lower version restrictions, but allowing install on modern Node installations (including bug fix releases in the 16.x line).