### PR TITLE
feat(stack): use serverless 'stackName' property if defined

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -120,7 +120,7 @@ class ServerlessSSMPublish {
         // Extract plugin variables
         this.region = this.serverless.service.provider.region;
 
-        this.stackName = util.format('%s-%s',
+        this.stackName = this.serverless.service.provider.stackName ?? util.format('%s-%s',
           this.serverless.service.getServiceName(),
           this.serverless.getProvider('aws').getStage(),
         );

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,7 @@ interface Provider {
   region: string;
   name: string;
   stage: string;
+  stackName?: string;
 }
 
 interface Service {


### PR DESCRIPTION
When the value is retrieved from the output of the Cloudformation stack, use the serverless 'stackName' property (if it's defined in the provider) to get the value that will be published to SSM.